### PR TITLE
Added auth middleware and fixed some types

### DIFF
--- a/src/controllers/product.ts
+++ b/src/controllers/product.ts
@@ -22,7 +22,7 @@ export const getProduct: RequestHandler = asyncHandler(
   async (req, res, next) => {
     const product = await Product.findById(req.params.id);
 
-    // If ID format is valid but it doesn't exist
+    // If ID format is valid but product doesn't exist
     if (!product) {
       return next(
         new ErrorResponse(`Product not found with id of ${req.params.id}`, 404)

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,62 @@
+import jsonwebtoken from 'jsonwebtoken';
+import asynchandler from 'express-async-handler';
+import { ErrorResponse } from '../utils/ErrorResponse';
+import User from '../models/User';
+import { NextFunction, Request, Response } from 'express';
+
+// Authorization via jsonwebtoken from cookie
+export const protect = asynchandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    let token;
+
+    if (
+      req.headers.authorization &&
+      req.headers.authorization.startsWith('Bearer')
+    ) {
+      token = req.headers.authorization.split(' ')[1];
+      // Gets the token without Bearer
+    }
+
+    // else if (req.cookies.token) {
+    //   token = req.cookies.token
+    // }
+
+    // Make sure token exists
+    if (!token) {
+      return next(
+        new ErrorResponse('Not authorised to access this route', 401)
+      );
+    }
+    try {
+      // Verify token
+      const secret = process.env.JWT_SECRET as jsonwebtoken.Secret;
+      const decoded: any = jsonwebtoken.verify(token, secret);
+      // Decoded will be in this format {id: string, iat: number, exp: number}
+
+      // TODO - figure out how to handle type here
+
+      req.user = await User.findById(decoded.id);
+
+      next();
+    } catch (err) {
+      return next(
+        new ErrorResponse('Not authorised to access this route', 401)
+      );
+    }
+  }
+);
+
+// Grant access to specific roles
+export const authorize = (...roles: string[]) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!roles.includes(req.user.role)) {
+      return next(
+        new ErrorResponse(
+          `User role ${req.user.role} is unauthorized to access this route`,
+          403
+        )
+      );
+    }
+    next();
+  };
+};

--- a/src/middleware/error.ts
+++ b/src/middleware/error.ts
@@ -4,6 +4,7 @@ import { ErrorResponse } from '../utils/ErrorResponse';
 const errorHandler: ErrorRequestHandler = (err, req, res, next): void => {
   let error = { ...err };
   error.message = err._message;
+  error.next = err.message; // Uses the message passed to next() in the controller, for example `Product not found with id of ${req.params.id}`
 
   // Log to console for dev
   console.log(err);
@@ -23,9 +24,14 @@ const errorHandler: ErrorRequestHandler = (err, req, res, next): void => {
     error = new ErrorResponse(message, 400);
   }
 
+  if (err.name === 'SyntaxError') {
+    const message = `Syntax Error`;
+    error = new ErrorResponse(message, 400);
+  }
+
   res.status(error.statusCode || 500).json({
     success: false,
-    error: error.message || 'Server Error',
+    error: error.message || error.next || 'Server error',
   });
 };
 

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -12,7 +12,7 @@ interface User extends mongoose.Document {
   createdAt: Date;
   getSignedJwtToken(): any;
   matchPassword(enteredPassword: string): any;
-  // If you want to have methods you gotta put them in interface
+  // If you want to export methods you gotta put them in interface
 }
 
 const UserSchema = new mongoose.Schema({
@@ -62,14 +62,11 @@ UserSchema.methods.getSignedJwtToken = function () {
   });
 };
 
-// Match user entered password to hashed paswword in database
-
+// Match user entered password to hashed password in database
 UserSchema.methods.matchPassword = async function (enteredPassword: string) {
   let user = this as User;
-  // weird workaround I don't fully understand
-
   return await bcryptjs.compare(enteredPassword, user.password);
 };
+// Exporting the schema with an interface applied
 const User = mongoose.model<User>('User', UserSchema);
 export default User;
-// Exporting the schema with an interface applied

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,9 +1,11 @@
 import express, { Router } from 'express';
-import { login, register } from '../controllers/auth';
+import { getMe, login, register } from '../controllers/auth';
+import { protect } from '../middleware/auth';
 
 const userRouter: Router = express.Router();
 
 userRouter.post('/register', register);
 userRouter.post('/login', login);
+userRouter.get('/me', protect, getMe);
 
 export default userRouter;

--- a/src/routes/product.ts
+++ b/src/routes/product.ts
@@ -6,15 +6,19 @@ import {
   deleteProduct,
   updateProduct,
 } from '../controllers/product';
+import { protect, authorize } from '../middleware/auth';
 
 const productRouter: Router = express.Router();
 
-productRouter.route('/').get(getProducts).post(createProduct);
+productRouter
+  .route('/')
+  .get(getProducts)
+  .post(protect, authorize('seller', 'admin'), createProduct);
 
 productRouter
   .route('/:id')
   .get(getProduct)
-  .put(updateProduct)
-  .delete(deleteProduct);
+  .put(protect, authorize('seller', 'admin'), updateProduct)
+  .delete(protect, authorize('seller', 'admin'), deleteProduct);
 
 export default productRouter;

--- a/src/utils/DeclareReqRes.ts
+++ b/src/utils/DeclareReqRes.ts
@@ -1,0 +1,10 @@
+// Goal of this is to avoid problems with accessing req.user and res.user which don't exist on default Request and Response interfaces in express
+
+declare namespace Express {
+  export interface Request {
+    user: any;
+  }
+  export interface Response {
+    user: any;
+  }
+}


### PR DESCRIPTION
Added:
1) Methods:
- creating cookies from generated jsonwebtoken with expire date,
- matching password with salted password stored in db,

2) Middleware:
- authorization via jsonwebtoken from cookie - it takes the cookie, gets the token, produces a decoded token with jsonwebtoken.verify, gets user id from it and checks if user exists in db
- granting access to specific roles - checks if user has specific role defined as enum in user schema - this will be later used to make it so only user with certain roles can add products etc

Improved:
1) Dealing with types - only 3 "any" types left, no typescript errors
2) Middleware: improved error handler to include err.name === 'SyntaxError' and if there's no error msg then it will use error msg passed to next() in given controller and if that doesn't exist then return "Server Error"